### PR TITLE
Rename options to reflect OSSC changes

### DIFF
--- a/gdq-crop.c
+++ b/gdq-crop.c
@@ -13,10 +13,10 @@ OBS_MODULE_USE_DEFAULT_LOCALE("gdq-crop", "en-US")
 	blog(level, "[gdqcrop]: " format, ##__VA_ARGS__)
 
 static const char *aspects[] = {
-	"HDMI Soure [16:9]",
-	"Component/SCART Source [4:3]",
+	"Default [16:9]",
+	"4:3 Override [4:3]",
 	"GameCube Game played on Wii Console [3:2]",
-	"override [Do not use!]"
+	"total override [Do not use!]"
 };
 
 #define NUM_ASPECTS (sizeof(aspects) / sizeof(const char *))
@@ -127,13 +127,13 @@ void modifyScaleFilter(obs_source_t *parent, obs_source_t *child, void *param) {
 	const char* resolutionName = param;
 	const char* res;
 
-	if (strcmp(resolutionName, "HDMI Soure [16:9]") == 0)
+	if (strcmp(resolutionName, "Default [16:9]") == 0)
 		res = "16:9";
-	else if (strcmp(resolutionName, "Component/SCART Source [4:3]") == 0)
+	else if (strcmp(resolutionName, "4:3 Override [4:3]") == 0)
 		res = "4:3";
 	else if (strcmp(resolutionName, "GameCube Game played on Wii Console [3:2]") == 0)
 		res = "3:2";
-	else if (strcmp(resolutionName, "override [Do not use!]") == 0)
+	else if (strcmp(resolutionName, "total override [Do not use!]") == 0)
 		return;
 
 	const char* name = obs_source_get_id(child);


### PR DESCRIPTION
The OSSC now handles scaling differently. It will maintain the aspect ratio of the source signal and add black bars around the edges as necessary to maintain the aspect ratio. Therefore, it is now much rarer to need to change the GDQ Scale setting.